### PR TITLE
vcf-to-gds improvements

### DIFF
--- a/ld-pruning/ld-pruning.wdl
+++ b/ld-pruning/ld-pruning.wdl
@@ -173,6 +173,7 @@ task subset_gds {
 		f.close()
 		CODE
 
+		echo "Calling R script subset_gds.R"
 		R -q --vanilla < /usr/local/analysis_pipeline/R/subset_gds.R --args subset_gds.config
 	}
 
@@ -275,6 +276,7 @@ task merge_gds {
 		exit()
 		CODE
 
+		echo "Calling R script merge_gds.R"
 		Rscript /usr/local/analysis_pipeline/R/merge_gds.R merge_gds.config
 	>>>
 
@@ -348,6 +350,7 @@ task check_merged_gds {
 		BASH_CHR=$(<chr_number)
 		echo "Chromosme number is ${BASH_CHR}"
 
+		echo "Calling R script check_merged_gds.R"
 		R -q --vanilla < /usr/local/analysis_pipeline/R/check_merged_gds.R --args check_merged_gds.config --chromosome ${BASH_CHR}
 	>>>
 

--- a/vcf-to-gds/checker/vcf-to-gds-checker.wdl
+++ b/vcf-to-gds/checker/vcf-to-gds-checker.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 # Caveat programmator: Please be sure to read the readme on Github
 
-import "https://raw.githubusercontent.com/DataBiosphere/analysis_pipeline_WDL/vcftogds-improvements/vcf-to-gds/vcf-to-gds.wdl" as test_run_vcftogds
+import "https://raw.githubusercontent.com/DataBiosphere/analysis_pipeline_WDL/v2.0.0/vcf-to-gds/vcf-to-gds.wdl" as test_run_vcftogds
 
 task md5sum {
 	input {

--- a/vcf-to-gds/checker/vcf-to-gds-checker.wdl
+++ b/vcf-to-gds/checker/vcf-to-gds-checker.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 # Caveat programmator: Please be sure to read the readme on Github
 
-import "https://raw.githubusercontent.com/DataBiosphere/analysis_pipeline_WDL/v2.0.0/vcf-to-gds/vcf-to-gds.wdl" as test_run_vcftogds
+import "https://raw.githubusercontent.com/DataBiosphere/analysis_pipeline_WDL/vcftogds-improvements/vcf-to-gds/vcf-to-gds.wdl" as test_run_vcftogds
 
 task md5sum {
 	input {

--- a/vcf-to-gds/vcf-to-gds.wdl
+++ b/vcf-to-gds/vcf-to-gds.wdl
@@ -78,46 +78,23 @@ task unique_variant_id {
 		def find_chromosome(file):
 			chr_array = []
 			chrom_num = split_on_chromosome(file)
-			if(unicode(str(chrom_num[1][1])).isnumeric()):
+			if(unicode(str(chrom_num[1])).isnumeric()):
 				# two digit number
-				chr_array.append(chrom_num[1][0])
-				chr_array.append(chrom_num[1][1])
+				chr_array.append(chrom_num[0])
+				chr_array.append(chrom_num[1])
 			else:
 				# one digit number or Y/X/M
-				chr_array.append(chrom_num[1][0])
+				chr_array.append(chrom_num[0])
 			return "".join(chr_array)
 
 		def split_on_chromosome(file):
-			# if input is "amishchr1.gds"
-			# output is ["amish", ".gds", "chr"]
-			chrom_num = file
-			if "chr" in chrom_num:
-				chrom_num = chrom_num.split("chr")
-				chrom_num.append("chr")
-			else:
-				return "error-invalid-inputs"
+			chrom_num = file.split("chr")[1]
 			return chrom_num
 
-		def write_config(chr_array, precisely_one_gds_split):
+		def write_config(chr_array, path):
 			f = open("unique_variant_ids.config", "a")
-			f.write("chromosomes ")
-			f.write("'")
-			for chr in chr_array:
-				f.write(chr)
-				f.write(" ")
-			f.write("'")
-			f.write("\ngds_file ")
-			f.write("'")
-			f.write(precisely_one_gds_split[0])  # first part
-			f.write(precisely_one_gds_split[2])  # string "chr"
-			f.write(" ")  # space where R script inserts chr number
-			if(unicode(str(precisely_one_gds_split[1][1])).isnumeric()):
-				# two digit number
-				f.write(precisely_one_gds_split[1][2:])
-			else:
-				# one digit number or Y/X/M
-				f.write(precisely_one_gds_split[1][1:])
-			f.write("'")
+			f.write('chromosomes "' + chrs + '"\n')
+			f.write('gds_file "' + path[0] + 'chr ' + path[1] + '"\n')
 			f.close()
 
 		gds_array_fullpath = ['~{sep="','" gdss}']
@@ -125,21 +102,20 @@ task unique_variant_id {
 		for fullpath in gds_array_fullpath:
 			gds_array_basenames.append(os.path.basename(fullpath))
 
+		a_file = gds_array_basenames[0]
+		chr = find_chromosome(a_file)
+		path = a_file.split('chr'+chr)
+
 		# make list of all chromosomes found in input files
 		chr_array = []
 		for gds_file in gds_array_basenames:
-			this_chr = find_chromosome(gds_file)
-			if this_chr == "error-invalid-inputs":
-				print("Unable to determine chromosome number from inputs.")
-				print("Please ensure your files contain ''chr'' followed by")
-				print("the number of letter of the chromosome (chr1, chr2, etc)")
-				exit(1)
-			else:
-				chr_array.append(this_chr)
+			chrom_num = find_chromosome(gds_file)
+			chr_array.append(chrom_num)
+		chrs = ' '.join(chr_array)
+
+		write_config(chrs, path)
 		
-		# assuming all gds files have same pattern in filename, any one will do
-		one_valid_gds_split = split_on_chromosome(gds_array_basenames[0])
-		write_config(chr_array, one_valid_gds_split)
+		exit()
 		CODE
 		
 		echo "Calling uniqueVariantIDs.R"


### PR DESCRIPTION
As requested by Julian and documented in #17. This streamlines vcf-to-gds and makes it closer in feel to ld-pruning. Its checker workflow has also been updated, and passed on Terra.

One small change was made to ld-pruning: Prints added before calling the R scripts. These are already present in the other workflows; this change makes them follow that pattern.

Pending approval, this will be the basis for tag v2.1.0