### PR TITLE
Assoc-agg checker hotfix

### DIFF
--- a/assoc-aggregate/checker/assoc-aggregate-checker.wdl
+++ b/assoc-aggregate/checker/assoc-aggregate-checker.wdl
@@ -1,6 +1,6 @@
 version 1.0
 import "https://raw.githubusercontent.com/DataBiosphere/analysis_pipeline_WDL/v7.0.0/assoc-aggregate/assoc-aggregate.wdl" as assoc_agg_wf
-import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.0.0/checker_tasks/arraycheck_task.wdl" as verify_array
+import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/checker_tasks/arraycheck_task.wdl" as verify_array
 
 workflow aggie_checker {
 	# If run as-is, this checker workflow will go through four configurations.


### PR DESCRIPTION
This is related to [#22 on the checker template repo](https://github.com/dockstore/checker-WDL-templates/issues/22). When the assoc-agg checker workflow imports v1.0.0 of the checker, the weights check errors out, even though it is a match. See #70 for more information.

This PR fixes the issue by updating to a new version of the checker workflow template that will throw a warning instead of erroring out if the first md5 sum fails and the RData exact equivalency check succeeds. This PR doesn't address how that happened in the first place. As always, more research is needed.

Tested on Terra, passes.