### PR TITLE
Hotfix assoc agg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ assoc-aggregate/cromwell-68.1.jar
 *.zip
 cwl.output.json
 job.json
+_test-data-and-truths_/assoc/big_silly_file_chr1.gds

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ This project is a Workflow Description Language (WDL) implementation of several 
 * Documentation of inputs, how each workflow works, and WDL-specific workarounds
 
 ## Usage
-These workflows are tested on both Terra and the local Cromwell execution engine. Example files are provided in `test-data-and-truths` and in `gs://topmed_workflow_testing/UWGAC_WDL/`.  
+These workflows are tested on both Terra and the local Cromwell execution engine. Example files are provided in `test-data-and-truths` and in `gs://topmed_workflow_testing/UWGAC_WDL/`.   
 
-Essentially all workflows which take in chromosome-level files share filename requirements. For these files, the chromosome must be included in the filename with the format `chr##` where `##` is the name of the chromosome (1-24 or X, Y). Chromosome can be included at any part of the filename provided they follow this format. For instance, data_subset_chr1.gds, data_chr1_subset.gds, and chr1_data_subset.gds are all valid names, while data_chromosome1_subset.gds and data_subset_c1.gds are not valid.  
+Essentially all workflows which take in chromosome-level files share filename requirements. For these files, the chromosome must be included in the filename with the format `chr##` where `##` is the name of the chromosome (1-24 or X, Y). Chromosome can be included at any part of the filename provided they follow this format. For instance, data_subset_chr1.gds, data_chr1_subset.gds, and chr1_data_subset.gds are all valid names, while data_chromosome1_subset.gds and data_subset_c1.gds are not valid. Note that the association aggregate, LD prune, and null model workflows additionally require that you have greater than one input GDS file (ie, input at least chr1 and chr2).  
 
 The original CWL pipelines had arguments relating to runtime such as `ncores` and `cluster_type` that do not apply to WDL. Please familiarize yourself with the [runtime attributes of WDL](https://cromwell.readthedocs.io/en/stable/RuntimeAttributes/) if you are unsure how your settings may transfer. For more information on specific runtime attributes for specific tasks, see [the further reading section](https://github.com/DataBiosphere/analysis_pipeline_WDL/main/README.md#further-reading).  
 

--- a/assoc-aggregate/assoc-aggregate.wdl
+++ b/assoc-aggregate/assoc-aggregate.wdl
@@ -427,8 +427,8 @@ task sbg_prepare_segments_1 {
 
 		# runtime attr
 		Int addldisk = 10
-		Int cpu = 2
-		Int memory = 4
+		Int cpu = 8
+		Int memory = 8
 		Int preempt = 2
 	}
 
@@ -630,6 +630,7 @@ task sbg_prepare_segments_1 {
 			os.mkdir("temp")
 
 		# make a bunch of zip files
+		print("Preparing zip file outputs...")
 		for i in range(0, max(output_segments)):
 			plusone = i+1
 			this_zip = ZipFile("dotprod%s.zip" % plusone, "w", allowZip64=True)

--- a/assoc-aggregate/assoc-aggregate.wdl
+++ b/assoc-aggregate/assoc-aggregate.wdl
@@ -466,8 +466,7 @@ task sbg_prepare_segments_1 {
 			done
 		fi
 
-		# python3, because we need zip64
-		python3 << CODE
+		python << CODE
 		IIsegments_fileII = "~{segments_file}"
 		IIinput_gds_filesII = ['~{sep="','" input_gds_files}']
 		IIvariant_include_filesII = ['~{sep="','" variant_include_files}']

--- a/assoc-aggregate/assoc-aggregate.wdl
+++ b/assoc-aggregate/assoc-aggregate.wdl
@@ -683,7 +683,8 @@ task sbg_prepare_segments_1 {
 				
 				this_zip.write("varinclude/%s" % output_variant_files[i])
 			this_zip.close()
-			print("Info: Wrote dotprod%s.zip in %s minutes" % [plusone, divmod((datetime.datetime.now()-beginning).total_seconds(), 60)[0]])
+			print("Info: Wrote dotprod%s.zip" % plusone)
+			print("Info: This took %s minutes" % divmod((datetime.datetime.now()-beginning).total_seconds(), 60)[0])
 		CODE
 	>>>
 

--- a/assoc-aggregate/assoc-aggregate.wdl
+++ b/assoc-aggregate/assoc-aggregate.wdl
@@ -429,7 +429,7 @@ task sbg_prepare_segments_1 {
 		Int addldisk = 50
 		Int cpu = 12
 		Int memory = 16
-		Int preempt = 1
+		Int preempt = 0
 	}
 
 	# estimate disk size required

--- a/assoc-aggregate/assoc-aggregate.wdl
+++ b/assoc-aggregate/assoc-aggregate.wdl
@@ -426,14 +426,14 @@ task sbg_prepare_segments_1 {
 		Array[File]? variant_include_files
 
 		# runtime attr
-		Int addldisk = 10
-		Int cpu = 8
-		Int memory = 8
-		Int preempt = 2
+		Int addldisk = 50
+		Int cpu = 12
+		Int memory = 16
+		Int preempt = 1
 	}
 
 	# estimate disk size required
-	Int gds_size = 2 * ceil(size(input_gds_files, "GB"))
+	Int gds_size = 5 * ceil(size(input_gds_files, "GB"))
 	Int seg_size = 2 * ceil(size(segments_file, "GB"))
 	Int agg_size = 2 * ceil(size(aggregate_files, "GB"))
 	Int dsk_size = gds_size + seg_size + agg_size + addldisk
@@ -725,10 +725,10 @@ task assoc_aggregate {
 		String? genome_build # acts as enum
 
 		# runtime attr
-		Int addldisk = 1
-		Int cpu = 1
-		Int memory = 8
-		Int preempt = 0
+		Int addldisk = 50
+		Int cpu = 4
+		Int memory = 16
+		Int preempt = 1
 
 		Boolean debug = false
 	}

--- a/assoc-aggregate/assoc-aggregate.wdl
+++ b/assoc-aggregate/assoc-aggregate.wdl
@@ -426,7 +426,7 @@ task sbg_prepare_segments_1 {
 		Array[File]? variant_include_files
 
 		# runtime attr
-		Int addldisk = 50
+		Int addldisk = 100
 		Int cpu = 12
 		Int memory = 16
 		Int preempt = 0
@@ -691,7 +691,7 @@ task sbg_prepare_segments_1 {
 	runtime {
 		cpu: cpu
 		docker: "uwgac/topmed-master@sha256:c564d54f5a3b9daed7a7677f860155f3b8c310b0771212c2eef1d6338f5c2600" # uwgac/topmed-master:2.12.0
-		disks: "local-disk " + dsk_size + " HDD"
+		disks: "local-disk " + dsk_size + " SSD"
 		memory: "${memory} GB"
 		preemptibles: "${preempt}"
 	}

--- a/assoc-aggregate/assoc-aggregate.wdl
+++ b/assoc-aggregate/assoc-aggregate.wdl
@@ -466,7 +466,8 @@ task sbg_prepare_segments_1 {
 			done
 		fi
 
-		python << CODE
+		# python3, because we need zip64
+		python3 << CODE
 		IIsegments_fileII = "~{segments_file}"
 		IIinput_gds_filesII = ['~{sep="','" input_gds_files}']
 		IIvariant_include_filesII = ['~{sep="','" variant_include_files}']

--- a/assoc-aggregate/assoc-aggregate.wdl
+++ b/assoc-aggregate/assoc-aggregate.wdl
@@ -16,7 +16,7 @@ task wdl_validate_inputs {
 		String? genome_build
 		String? aggregate_type
 		String? test
-		Int num_gds_files
+		Int? num_gds_files
 
 		# no runtime attr because this is a trivial task that does not scale
 	}
@@ -24,11 +24,11 @@ task wdl_validate_inputs {
 	command <<<
 		set -eux -o pipefail
 
-		echo "~{num_gds_files}"
-
-		if [ "~{num_gds_files}" = "1" ]; then
-			echo "Wrong number of files given - make sure to include more than one GDS file."
-			exit 22
+		if [[ ~{num_gds_files} = 1 ]]
+		then
+			echo "Invalid input - you need to put it at least two GDS files (preferably consecutive ones, like chr1 and chr2)"
+			exit 1
+		fi
 
 		#acceptable genome builds: ("hg38" "hg19")
 		#acceptable aggreg types:  ("allele" "position")

--- a/assoc-aggregate/checker/assoc-aggregate-checker.json
+++ b/assoc-aggregate/checker/assoc-aggregate-checker.json
@@ -1,5 +1,5 @@
 {
-  "aggie_checker.input_gds_files": ["_test-data-and-truths_/assoc/1KG_phase3_subset_chr1.gds", "_test-data-and-truths_/gds/a_vcf2gds/1KG_phase3_subset_chr2_butwithadifferentname.gds"],
+  "aggie_checker.input_gds_files": ["_test-data-and-truths_/assoc/1KG_phase3_subset_chr1.gds"],
   "aggie_checker.phenotype_file": "_test-data-and-truths_/null_model/1KG_phase3_subset_annot.RData",
   "aggie_checker.null_model_file": "_test-data-and-truths_/assoc/null_model.RData",
   "aggie_checker.variant_include_files": ["_test-data-and-truths_/assoc/variant_include_chr1.RData", "_test-data-and-truths_/assoc/variant_include_chr2.RData"],

--- a/assoc-aggregate/checker/assoc-aggregate-checker.json
+++ b/assoc-aggregate/checker/assoc-aggregate-checker.json
@@ -1,5 +1,5 @@
 {
-  "aggie_checker.input_gds_files": ["_test-data-and-truths_/assoc/1KG_phase3_subset_chr1.gds"],
+  "aggie_checker.input_gds_files": ["_test-data-and-truths_/assoc/1KG_phase3_subset_chr1.gds", "_test-data-and-truths_/gds/a_vcf2gds/1KG_phase3_subset_chr2_butwithadifferentname.gds"],
   "aggie_checker.phenotype_file": "_test-data-and-truths_/null_model/1KG_phase3_subset_annot.RData",
   "aggie_checker.null_model_file": "_test-data-and-truths_/assoc/null_model.RData",
   "aggie_checker.variant_include_files": ["_test-data-and-truths_/assoc/variant_include_chr1.RData", "_test-data-and-truths_/assoc/variant_include_chr2.RData"],

--- a/assoc-aggregate/checker/assoc-aggregate-checker.wdl
+++ b/assoc-aggregate/checker/assoc-aggregate-checker.wdl
@@ -1,6 +1,6 @@
 version 1.0
-#import "https://raw.githubusercontent.com/DataBiosphere/analysis_pipeline_WDL/v7.0.0/assoc-aggregate/assoc-aggregate.wdl" as assoc_agg_wf
-import "../assoc-aggregate.wdl" as assoc_agg_wf # use this if you want to test a local version
+import "https://raw.githubusercontent.com/DataBiosphere/analysis_pipeline_WDL/v7.0.0/assoc-aggregate/assoc-aggregate.wdl" as assoc_agg_wf
+#import "../assoc-aggregate.wdl" as assoc_agg_wf # use this if you want to test a local version
 import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/checker_tasks/arraycheck_task.wdl" as verify_array
 
 workflow aggie_checker {

--- a/assoc-aggregate/checker/assoc-aggregate-checker.wdl
+++ b/assoc-aggregate/checker/assoc-aggregate-checker.wdl
@@ -1,5 +1,6 @@
 version 1.0
-import "https://raw.githubusercontent.com/DataBiosphere/analysis_pipeline_WDL/v7.0.0/assoc-aggregate/assoc-aggregate.wdl" as assoc_agg_wf
+#import "https://raw.githubusercontent.com/DataBiosphere/analysis_pipeline_WDL/v7.0.0/assoc-aggregate/assoc-aggregate.wdl" as assoc_agg_wf
+import "../assoc-aggregate.wdl" as assoc_agg_wf # use this if you want to test a local version
 import "https://raw.githubusercontent.com/dockstore/checker-WDL-templates/v1.1.0/checker_tasks/arraycheck_task.wdl" as verify_array
 
 workflow aggie_checker {

--- a/assoc-aggregate/prepare_segments_1.py
+++ b/assoc-aggregate/prepare_segments_1.py
@@ -221,4 +221,5 @@ for i in range(0, max(output_segments)):
 		
 		this_zip.write("varinclude/%s" % output_variant_files[i])
 	this_zip.close()
-	print("Info: Wrote dotprod%s.zip in %s minutes" % [plusone, divmod((datetime.datetime.now()-beginning).total_seconds(), 60)[0]])
+	print("Info: Wrote dotprod%s.zip" % plusone)
+	print("Info: This took %s minutes" % divmod((datetime.datetime.now()-beginning).total_seconds(), 60)[0])

--- a/assoc-aggregate/readme.md
+++ b/assoc-aggregate/readme.md
@@ -31,6 +31,10 @@ Aggregate tests are typically used to jointly test rare variants. This workflow 
 
 * Do not use this pipeline with non-consecutive chromosomes. A run containing chr1, chr2, and chr3 will work. A run containing chr1, chr20, and chr13 may not. (Non-autosomes excluded -- a run containing chr1, chr2, and chrX will not error out, but as noted above chrX will be dropped.)
 
+* Do not use this pipeline on only one chromosome.
+
+* If your data consists of GDS files that are >10 GB, it is *recommended* to set a lower number of segments in order to decrease delocalization time in the prepare segments task. For reference, it took almost two hours for a 25-segment output of 4.3 GB GDS files to finish delocalizing in prepare segments. I am currently seeking additional guidance from Cromwell and Terra devs on handling this bottleneck better.
+
 ## Sample Inputs
 * terra-allele, local-allele, and the first part of the checker workflow are based upon [assoc_aggregate_allele.config](https://github.com/UW-GAC/analysis_pipeline/blob/master/testdata/assoc_aggregate_allele.config)
 * terra-position, local-position, and the second part of the checker workflow are based upon [assoc_aggregate_position.config](https://github.com/UW-GAC/analysis_pipeline/blob/master/testdata/assoc_aggregate_position.config)

--- a/ld-pruning/ld-pruning-terra.json
+++ b/ld-pruning/ld-pruning-terra.json
@@ -23,5 +23,8 @@
  "gs://topmed_workflow_testing/UWGAC_WDL/checker/a_vcf2gds/1KG_phase3_subset_chr21.gds",
  "gs://topmed_workflow_testing/UWGAC_WDL/checker/a_vcf2gds/1KG_phase3_subset_chr22.gds"
 ],
+  "ldpruning.ld_pruning.addldisk": "5",
+  "ldpruning.ld_pruning.cpu": "2",
+  "ldpruning.ld_pruning.memory": "4",
   "ldpruning.ld_pruning.genome_build": "hg38"
 }

--- a/ld-pruning/ld-pruning.wdl
+++ b/ld-pruning/ld-pruning.wdl
@@ -18,9 +18,9 @@ task ld_pruning {
 		String? out_prefix
 		
 		# runtime attributes
-		Int addldisk = 5
-		Int cpu = 2
-		Int memory = 4
+		Int addldisk = 10
+		Int cpu = 4
+		Int memory = 8
 		Int preempt = 3
 	}
 
@@ -201,7 +201,7 @@ task merge_gds {
 		# runtime attributes
 		Int addldisk = 5
 		Int cpu = 2
-		Int memory = 4
+		Int memory = 8
 		Int preempt = 3
 	}
 

--- a/vcf-to-gds/vcf-to-gds-terra.json
+++ b/vcf-to-gds/vcf-to-gds-terra.json
@@ -25,7 +25,10 @@
  "gs://topmed_workflow_testing/UWGAC_WDL/1KG_phase3_subset_chrX.vcf.gz"
 ],
   "vcftogds.vcf2gds.addldisk": 1,
+  "vcftogds.vcf2gds.cpu": 2,
+  "vcftogds.vcf2gds.memory": 4,
   "vcftogds.unique_variant_id.addldisk": 1,
+  "vcftogds.unique_variant_id.memory": 4,
   "vcftogds.check_gds": true,
   "vcftogds.check_gds.addldisk": 1,
   "vcftogds.check_gds.preempt": 1

--- a/vcf-to-gds/vcf-to-gds.wdl
+++ b/vcf-to-gds/vcf-to-gds.wdl
@@ -7,10 +7,11 @@ task vcf2gds {
 		String debug_basename = basename(vcf)
 		String debug_basenamesub = basename(sub(vcf, "\.vcf\.gz(?!.{1,})|\.vcf\.bgz(?!.{5,})|\.vcf(?!.{5,})|\.bcf(?!.{1,})", ".gds"))
 		Array[String] format # vcf formats to keep
+
 		# runtime attributes
 		Int addldisk = 1
-		Int cpu = 2
-		Int memory = 4
+		Int cpu = 4
+		Int memory = 8
 		Int preempt = 3
 	}
 	command {
@@ -73,10 +74,11 @@ task vcf2gds {
 task unique_variant_id {
 	input {
 		Array[File] gdss
+
 		# runtime attr
 		Int addldisk = 1
 		Int cpu = 2
-		Int memory = 4
+		Int memory = 8
 		Int preempt = 2
 	}
 	command <<<


### PR DESCRIPTION
* Readme now says that LD prune, assoc-agg, and null model all need 2+ GDS files. I'm only certain that assoc-agg needs it, but it's likely for those other two so let's add them in just for good measure!
* assoc-agg's input checker will now ensure at least two GDS files are input, without having to localize them
* assoc-agg will no longer sneakily try to run sbg_gds_renamer before the input checker is finished
* assoc-agg **should** now be able to handle large input files (still in testing)