### PR TITLE
Run all checker workflows from a single script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ assoc-aggregate/cromwell-68.1.jar
 *.zip
 cwl.output.json
 job.json
+_test-data-and-truths_/assoc/big_silly_file_chr1.gds

--- a/_test-data-and-truths_/runtests.sh
+++ b/_test-data-and-truths_/runtests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# run from the parent directory analysis_pipeline_wdl, not from the test data directory
+
+ddoc vcf-to-gds/checker/vcf-to-gds-checker.wdl --json vcf-to-gds/checker/vcf-to-gds-checker.json
+ddoc ld-pruning/checker/ld-pruning-checker.wdl --json ld-pruning/checker/ld-pruning-checker.json
+ddoc king/checker/king-checker.wdl --json king/checker/king-checker.json
+ddoc null-model/checker/null-model-checker.wdl --json null-model/checker/null-model-checker.json
+ddoc assoc-aggregate/checker/assoc-aggregate-checker.wdl --json assoc-aggregate/checker/assoc-aggregate-checker.json


### PR DESCRIPTION
A good way to melt your RAM on a Friday afternoon.

Todo:
* Stop using my dockstore alias, use the full command instead
* Make sure everything doesn't run at once